### PR TITLE
ProjectManager: keep list scroll position when changing status via co…

### DIFF
--- a/inc/class.projectmanager_ui.inc.php
+++ b/inc/class.projectmanager_ui.inc.php
@@ -979,6 +979,7 @@ class projectmanager_ui extends projectmanager_bo
 			),
 			'status' => array(
 				'icon' => 'apply',
+				'onExecute' => 'javaScript:app.projectmanager.change_status',
 				'caption' => 'Modify status',
 				'group' => $group,
 				'children' => self::$status_labels,
@@ -1023,6 +1024,46 @@ class projectmanager_ui extends projectmanager_bo
 		}
 		//_debug_array($actions);
 		return $actions;
+	}
+
+	/**
+	 * Run a context-menu action (eg. status_*) via AJAX without a form submit
+	 * and refresh only the affected rows in place, so the list keeps its
+	 * scroll position (same pattern as infolog_ui::ajax_action).
+	 *
+	 * @param string $action eg. 'status_active'
+	 * @param array $selected pm_id's
+	 * @param boolean $select_all true if "all" selection is used
+	 * @param boolean $sources_too change status of datasources too
+	 */
+	public function ajax_action($action, $selected, $select_all = false, $sources_too = false)
+	{
+		$success = $failed = 0;
+		$action_msg = $msg = '';
+		$selected = array_values((array)$selected);
+
+		if ($this->action($action, $selected, $select_all,
+			$success, $failed, $action_msg, 'project_list', $msg, $sources_too))
+		{
+			$msg .= lang('%1 project(s) %2', $success, $action_msg);
+		}
+		else
+		{
+			$msg .= lang('%1 project(s) %2, %3 failed because of insufficent rights !!!',
+				$success, $action_msg, $failed);
+		}
+		if (!$select_all && $success && !$failed)
+		{
+			// punctual selection: update only the affected rows, keep scroll position
+			Api\Json\Response::get()->call('egw.refresh', $msg, 'projectmanager',
+				$selected, 'update-in-place', null, null, null, 'success');
+		}
+		else
+		{
+			// select-all or (partial) failure: classic full refresh
+			Api\Json\Response::get()->call('egw.refresh', $msg, 'projectmanager',
+				null, null, null, null, null, $failed ? 'error' : 'success');
+		}
 	}
 
 	/**

--- a/js/app.ts
+++ b/js/app.ts
@@ -1091,6 +1091,39 @@ export class ProjectmanagerApp extends EgwApp
 	}
 
 	/**
+	 * Change project status from the list's context menu via AJAX (no form
+	 * submit): only the affected rows get refreshed in place, so the list
+	 * keeps its scroll position eg. while sequentially reviewing projects.
+	 *
+	 * @param {egwAction} action eg. status_active
+	 * @param {egwActionObject[]} selected
+	 */
+	change_status(action, selected)
+	{
+		// find the nextmatch like nm_action() does: walk up the action tree
+		let nm = null, a = action;
+		while(!nm && a)
+		{
+			if(a.data && a.data.nextmatch) nm = a.data.nextmatch;
+			a = a.parent;
+		}
+		const all = nm && nm.getSelection ? !!nm.getSelection().all : false;
+		const ids = [];
+		for(let i = 0; i < selected.length; i++)
+		{
+			ids.push(String(selected[i].id).split("::").pop());
+		}
+		const sources_too = !!action.getManager().getActionById('sources_too')?.checked;
+		if(all && !confirm(this.egw.lang('Apply this action on the whole query, NOT only the shown rows?')))
+		{
+			return;
+		}
+		egw.json('projectmanager.projectmanager_ui.ajax_action', [action.id, ids, all, sources_too],
+			null, this, true, this
+		).sendRequest(true);
+	}
+
+	/**
 	 * Enabled check for project element action, used by context menu
 	 *
 	 * @param {egwAction} action


### PR DESCRIPTION
The "Modify status" context-menu action used the default nm_action=submit, which submits the whole nextmatch form and re-renders the project list, scrolling it back to the top after every status change — very tedious when sequentially reviewing many projects.

This routes the action through a dedicated ajax_action() (same pattern as infolog_ui::ajax_action and projectmanager_elements_ui::ajax_action) and refreshes only the affected rows in place (update-in-place), so the list keeps its scroll position. "Select all" and failure cases keep the classic full refresh.

Tested on 26.5.20260507: scroll position is preserved on single and multi punctual selection, the row updates in place, status is saved, no console/PHP errors.

Discussion: https://help.egroupware.org/t/projectmanager-context-menu-modify-status-reloads-the-whole-project-list-and-scrolls-back-to-top/79838