### PR TITLE
ProjectManager: also keep scroll position on category change via cont…

### DIFF
--- a/inc/class.projectmanager_ui.inc.php
+++ b/inc/class.projectmanager_ui.inc.php
@@ -958,6 +958,9 @@ class projectmanager_ui extends projectmanager_bo
 			'cat' => Etemplate\Widget\Nextmatch::category_action(
 				'projectmanager',$group,'Change category','cat_'
 			)+array(
+				// reuse the same in-place ajax handler as "Modify status", so the
+				// list keeps its scroll position instead of reloading to the top
+				'onExecute' => 'javaScript:app.projectmanager.change_status',
 				'disableClass' => 'rowNoEdit',
 				'confirm_mass_selection' => true,
 			),

--- a/js/app.ts
+++ b/js/app.ts
@@ -1091,11 +1091,11 @@ export class ProjectmanagerApp extends EgwApp
 	}
 
 	/**
-	 * Change project status from the list's context menu via AJAX (no form
-	 * submit): only the affected rows get refreshed in place, so the list
-	 * keeps its scroll position eg. while sequentially reviewing projects.
+	 * Change project status or category from the list's context menu via AJAX
+	 * (no form submit): only the affected rows get refreshed in place, so the
+	 * list keeps its scroll position eg. while sequentially reviewing projects.
 	 *
-	 * @param {egwAction} action eg. status_active
+	 * @param {egwAction} action eg. status_active or cat_123
 	 * @param {egwActionObject[]} selected
 	 */
 	change_status(action, selected)


### PR DESCRIPTION
…ext menu

Follow-up to #2 (which fixed "Modify status"). The "Change category" context-menu action had the exact same behavior: it submitted the whole nextmatch form and re-rendered the project list, scrolling back to the top.

Wire it to the same in-place ajax handler (app.projectmanager.change_status -> projectmanager_ui::ajax_action), so only the affected rows are refreshed and the list keeps its scroll position. The handler is already generic (it just forwards the action id, and action() already dispatches cat_*).

Discussion: https://help.egroupware.org/t/projectmanager-context-menu-modify-status-reloads-the-whole-project-list-and-scrolls-back-to-top/79838